### PR TITLE
Feature get data deputados

### DIFF
--- a/src/ingestion/main.py
+++ b/src/ingestion/main.py
@@ -1,0 +1,97 @@
+import requests
+import awswrangler as wr
+import pandas as pd
+from datetime import datetime
+import logging
+from src.utils.main import upload_s3_parquet_file
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+def get_current_legislatura():
+    current_date = datetime.now().strftime('%Y-%m-%d')
+
+    url = "https://dadosabertos.camara.leg.br/api/v2/legislaturas"
+    params = {
+        'data': current_date,
+        'ordem':'DESC',
+        'ordenarPor': 'id'
+    }
+    try:
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+    
+        data = response.json().get('dados',[])
+        if not data:
+            logging.error("No data found")
+            return 
+        return data[0].get('id')
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Request error occurred: {e}")
+    except ValueError as e:
+        logging.error(f"Error processing JSON response: {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+
+
+def get_current_deputados(id):
+    url = 'https://dadosabertos.camara.leg.br/api/v2/deputados'
+
+    params = {
+        'idLegislatura': id,
+        'ordem': 'ASC',
+        'ordenarPor': 'nome'
+    }
+    try:
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+    
+        data = response.json()
+        if not data:
+            logging.error("No data found")
+            return 
+        return data
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Request error occurred: {e}")
+    except ValueError as e:
+        logging.error(f"Error processing JSON response: {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+
+def get_despesas_per_deputado(id_deputado:str):
+    url = f"https://dadosabertos.camara.leg.br/api/v2/deputados/{id_deputado}/despesas"
+    params = {
+        'ordem':'DESC',
+        'ordenarPor': 'ano'
+    }
+    try:
+        response = requests.get(url, params=params)
+        response.raise_for_status()
+    
+        data = response.json()
+        if not data:
+            logging.error("No data found")
+            return 
+        return data
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Request error occurred: {e}")
+    except ValueError as e:
+        logging.error(f"Error processing JSON response: {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+
+
+def lambda_handler(event,context):
+    current_legislatura_id = get_current_legislatura()
+
+
+
+current_legislatura_id = get_current_legislatura()
+data =  get_current_deputados(current_legislatura_id)
+df = pd.DataFrame.from_dict(data['dados'])
+df_spending = pd.DataFrame()
+for x in df.id.to_list():
+    data_spending =  get_despesas_per_deputado(x)
+    temp_df = pd.DataFrame.from_dict(data_spending['dados'])
+    temp_df['id'] = x
+    df_spending = pd.concat([df_spending,temp_df],ignore_index=True)
+
+upload_s3_parquet_file(df=df,path='s3://gastos-deputados-9723-dev/deputados/')
+upload_s3_parquet_file(df=df_spending,path='s3://gastos-deputados-9723-dev/gastos/')

--- a/src/utils/main.py
+++ b/src/utils/main.py
@@ -6,7 +6,6 @@ def upload_s3_parquet_file(path:str,df:pd.DataFrame):
     Uploads a Pandas DataFrame to an S3 bucket as a Parquet file.
 
     Args:
-        bucket_name (str): The name of the S3 bucket.
         path (str): The full S3 path where the Parquet file will be stored.
         df (pd.DataFrame): The DataFrame to be uploaded.
     
@@ -16,6 +15,6 @@ def upload_s3_parquet_file(path:str,df:pd.DataFrame):
     wr.s3.to_parquet(
         df=df,
         path=path,
-        dataset=False
+        dataset=True
     )
     logging.info("Files uploaded")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,18 +13,19 @@ def s3_bucket():
 def test_upload_s3_parquet_file_integration(s3_bucket):
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
 
-    path = f"s3://{s3_bucket}/test-folder/data.parquet"
+    path = f"s3://{s3_bucket}/test-folder/"
     
     upload_s3_parquet_file(path, df)
     s3_client= boto3.client('s3')
     try:
-        s3_client.head_object(Bucket=s3_bucket,Key="test-folder/data.parquet")
+        response = s3_client.list_objects_v2(Bucket=s3_bucket,Prefix="test-folder/")
+        assert 'Contents' in response and len(response['Contents']) > 0, f"No files found at {path}"
     except s3_client.exceptions.ClientError:
         assert False, f"File not found at {path}"
 
-    s3_client.delete_object(Bucket=s3_bucket, Key="test-folder/data.parquet")
-    try:
-        s3_client.head_object(Bucket=s3_bucket, Key="test-folder/data.parquet")
-        assert False, f"File not deleted at {path}"
-    except s3_client.exceptions.ClientError:
-        pass
+
+    for obj in response.get('Contents', []):
+        s3_client.delete_object(Bucket=s3_bucket, Key=obj['Key'])
+    
+    response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix="test-folder/")
+    assert 'Contents' not in response or len(response['Contents']) == 0, f"Files not deleted at {path}"


### PR DESCRIPTION
# Pull Request: Enhance Data Ingestion and S3 Upload Logic

## Description
This PR introduces multiple enhancements and fixes to the data ingestion pipeline and S3 upload functionality.

## Changes

### 🚀 **Ingestion Pipeline (`src/ingestion/main.py`)**
- Implemented functions to fetch:
  - ✅ The current legislative period (`get_current_legislatura`)
  - ✅ Deputies for the current legislative period (`get_current_deputados`)
  - ✅ Expenses per deputy (`get_despesas_per_deputado`)
- Improved error handling with structured logging.
- Extracted deputy and expense data into Pandas DataFrames.
- Updated S3 upload paths:
  - 📂 Deputies data stored in `s3://gastos-deputados-9723-dev/deputados/`
  - 📂 Deputies' expenses stored in `s3://gastos-deputados-9723-dev/gastos/`

### 🔧 **Utility Function (`src/utils/main.py`)**
- Updated `upload_s3_parquet_file`:
  - 🔄 Changed `dataset=False` to `dataset=True` to support partitioned Parquet datasets.

### 🧪 **Testing (`test/test_utils.py`)**
- Improved S3 integration test:
  - 📌 Adjusted test to validate folder-based Parquet dataset upload.
  - ✅ Improved S3 file existence and deletion assertions.

---

This update enhances **reliability** and **correctness** in data ingestion and storage. 🚀
